### PR TITLE
Fixed URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # apps
 Coordinating writing apps on top of ipfs, and their concerns.
 
-This is a discussion repo. That means that all of the work gets done in the [issues](issues). Go check them out! 
+This is a discussion repo. That means that all of the work gets done in the [issues](https://github.com/ipfs/apps/issues). Go check them out! 


### PR DESCRIPTION
It was pointing to the wrong page, the relative URL was referencing an "issue" file which doesn't exist :+1:
